### PR TITLE
React Native 25+ & Disable scrolling, zooming, etc.

### DIFF
--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var {
     View,
     WebView
-} = React;
+} = require('react-native');
 
 var Canvas = React.createClass({
     propTypes: {

--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -26,6 +26,8 @@ var Canvas = React.createClass({
                     underlayColor={'transparent'}
                     style={this.props.style}
                     javaScriptEnabled={true}
+                    scrollEnabled={false}
+                    bounces={false}
                 />
             </View>
         );

--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -17,7 +17,7 @@ var Canvas = React.createClass({
         var contextString = JSON.stringify(this.props.context);
         var renderString = this.props.render.toString();
         return (
-            <View>
+            <View pointerEvents={'none'}>
                 <WebView
                     automaticallyAdjustContentInsets={false}
                     contentInset={{top: 0, right: 0, bottom: 0, left: 0}}

--- a/lib/QRCode.js
+++ b/lib/QRCode.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var Canvas = require('./Canvas.js');
 var qr = require('qr.js');
 var {
     Text,
     WebView,
     View
-} = React;
+} = require('react-native');
 
 function getBackingStorePixelRatio(ctx) {
   return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-qrcode-logo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
React 25+ requires that you import `React` from the `react` package instead of `react-native`.

Additionally, I added props to the `Canvas` component's `View` and `WebView` to disable touch, zooming, scrolling, etc. since QR codes are meant to be static.
